### PR TITLE
Update autodeploy_branch to dev32_upgrade

### DIFF
--- a/blueprint_config.yml
+++ b/blueprint_config.yml
@@ -4,7 +4,7 @@ version:
   minor: 1
 branches:
   develop:
-    autodeploy_branch: dev30_upgrade
+    autodeploy_branch: dev32_upgrade
     ecrregistry: false
     build_options: -P build
 


### PR DESCRIPTION
This PR updates the autodeploy_branch in blueprint_config.yml from dev30_upgrade to dev32_upgrade.